### PR TITLE
fix: `resources-release-optimize.ap_`'s path is never right

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,6 @@
 android.experimental.enableNewResourceShrinker.preciseShrinking=true
 android.enableAppCompileTimeRClass=true
+android.enableResourceOptimizations=false
 android.useAndroidX=true
 org.gradle.parallel=true
 android.native.buildOutput=verbose


### PR DESCRIPTION
by disabling Android Resource Optimizations

See: https://njuptrain.site/posts/AGP-BuildTools-%E4%B9%8B%E9%97%B4%E7%9A%84%E5%85%B3%E7%B3%BB/