### PR TITLE
fix: modifications due to upstream breaking changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,8 +94,7 @@ jobs:
         cd api
         echo 'org.gradle.jvmargs=-Xmx2048m' >> gradle.properties
         ./gradlew :api:publishApiPublicationToMavenLocal
-        cd ..
-        cd service
+        cd ../service
         echo 'org.gradle.jvmargs=-Xmx2048m' >> gradle.properties
         ./gradlew :interface:publishInterfacePublicationToMavenLocal
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -59,7 +59,7 @@ val androidTargetCompatibility by extra(JavaVersion.VERSION_21)
 val androidCmakeVersion by extra("3.28.0+")
 
 tasks.register<Delete>("clean") {
-    delete(rootProject.buildDir)
+    delete(rootProject.layout.buildDirectory)
 }
 
 listOf("Debug", "Release").forEach { variant ->

--- a/patch-loader/src/main/jni/include/art/runtime/jit/profile_saver.h
+++ b/patch-loader/src/main/jni/include/art/runtime/jit/profile_saver.h
@@ -10,45 +10,47 @@
 using namespace lsplant;
 
 namespace art {
-    CREATE_MEM_HOOK_STUB_ENTRY(
+    inline static Hooker<
             "_ZN3art12ProfileSaver20ProcessProfilingInfoEbPt",
-            bool, ProcessProfilingInfo, (void * thiz, bool, uint16_t *), {
-                LOGD("skipped profile saving");
-                return true;
-            });
+            bool(void*, bool, uint16_t *)
+    > ProcessProfilingInfo_ = +[](void* thiz, bool, uint16_t *) -> bool {
+        LOGD("skipped profile saving");
+        return true;
+    };
 
-    CREATE_MEM_HOOK_STUB_ENTRY(
+    inline static Hooker<
             "_ZN3art12ProfileSaver20ProcessProfilingInfoEbbPt",
-            bool, ProcessProfilingInfoWithBool, (void * thiz, bool, bool, uint16_t *), {
-                LOGD("skipped profile saving");
-                return true;
-            });
+            bool(void*, bool, bool, uint16_t *)
+    > ProcessProfilingInfoWithBool_ = +[](void* thiz, bool, bool, uint16_t *) -> bool {
+        LOGD("skipped profile saving");
+        return true;
+    };
 
-    CREATE_HOOK_STUB_ENTRY(
+    inline static Hooker<
             "execve",
-            int, execve, (const char *pathname, const char *argv[], char *const envp[]), {
-                if (strstr(pathname, "dex2oat")) {
-                    size_t count = 0;
-                    while (argv[count++] != nullptr);
-                    std::unique_ptr<const char *[]> new_args = std::make_unique<const char *[]>(
-                            count + 1);
-                    for (size_t i = 0; i < count - 1; ++i)
-                        new_args[i] = argv[i];
-                    new_args[count - 1] = "--inline-max-code-units=0";
-                    new_args[count] = nullptr;
+            int(const char*, const char*[], char* const[])
+    > execve_ = +[](const char *pathname, const char *argv[], char *const envp[]) {
+        if (strstr(pathname, "dex2oat")) {
+            size_t count = 0;
+            while (argv[count++] != nullptr);
+            std::unique_ptr<const char *[]> new_args = std::make_unique<const char *[]>(
+                    count + 1);
+            for (size_t i = 0; i < count - 1; ++i)
+                new_args[i] = argv[i];
+            new_args[count - 1] = "--inline-max-code-units=0";
+            new_args[count] = nullptr;
 
-                    LOGD("dex2oat by disable inline!");
-                    int ret = backup(pathname, new_args.get(), envp);
-                    return ret;
-                }
-                int ret = backup(pathname, argv, envp);
-                return ret;
-            });
-
+            LOGD("dex2oat by disable inline!");
+            int ret = execve_(pathname, new_args.get(), envp);
+            return ret;
+        }
+        int ret = execve_(pathname, argv, envp);
+        return ret;
+    };
 
     static void DisableInline(const HookHandler &handler) {
-        HookSyms(handler, ProcessProfilingInfo, ProcessProfilingInfoWithBool);
-        HookSymNoHandle(handler, reinterpret_cast<void*>(&::execve), execve);
+        handler.hook(ProcessProfilingInfo_, ProcessProfilingInfoWithBool_);
+        handler.hook(execve_);
     }
 }
 


### PR DESCRIPTION
1. The macros, `CREATE_MEM_HOOK_STUB_ENTRY`, `CREATE_HOOK_STUB_ENTRY` no longer exist, so corresponding references be modified with `lsplant::Hooker` appropriately. And all `lsplant::MemberHooker` usages in this repository were wrong because they are not inside C++ classes.

2. The functions `HookSyms` and `HookSymNoHandle` no longer exist, so they be replaced with `handler.hook`. But to specify the symbols to find, use templates of `lsplant::Hooker` with appropriate `lsplant::InitInfo`.

3. There is a place referenced `handler` wrongly, and need a fix.